### PR TITLE
Command line improvements

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,15 +1,79 @@
+<!-- START doctoc generated TOC please keep comment here to allow auto update -->
+<!-- DON'T EDIT THIS SECTION, INSTEAD RE-RUN doctoc TO UPDATE -->
+
+
+- [orloclient](#orloclient)
+  - [Installation](#installation)
+  - [Configuration](#configuration)
+  - [Command-line Usage](#command-line-usage)
+  - [Usage in Python](#usage-in-python)
+  - [Tests](#tests)
+
+<!-- END doctoc generated TOC please keep comment here to allow auto update -->
+
 # orloclient
 
 Python client for the [Orlo](https://github.com/eBayClassifiedsGroup/orlo) server.
 
-# Installation
+## Installation
 ```
 pip install orloclient
 ```
 
-# Usage
+## Configuration
 
-With an Orlo server running on localhost:5000:
+If orlo server is on the same box, put a section in /etc/orlo.ini:
+```
+[client]
+uri=http://orlo.host
+```
+
+Otherwise, orloclient will read the ini file above from `~/.orlo.ini` or `./orlo.ini`.
+
+This is the only configuration at present and is not required, it just saves you from
+constantly having to type `--uri http://orlo.host` on the command line.
+
+## Command-line Usage
+
+With an Orlo server running on localhost:5000, and client/uri configured in orlo.ini:
+
+```
+$ orloclient create-release -p test -u alex
+Created release with id e42a478f-cc08-42e9-a9fb-c98ec65c414d
+
+$ orloclient create-package e42a478f-cc08-42e9-a9fb-c98ec65c414d test-package 1.0.0
+Created package with id 7510ffc0-4f0e-4fc1-925f-96ecb84e6db8
+
+$ orloclient start 7510ffc0-4f0e-4fc1-925f-96ecb84e6db8
+
+$ orloclient stop 7510ffc0-4f0e-4fc1-925f-96ecb84e6db8
+
+$ orloclient list
+[
+  {
+    "user": "alex",
+    "platforms": [
+      "test"
+    ],
+    "packages": [
+      {
+        "status": "SUCCESSFUL",
+        "release_id": "e42a478f-cc08-42e9-a9fb-c98ec65c414d",
+        "id": "7510ffc0-4f0e-4fc1-925f-96ecb84e6db8",
+        {...}
+      }
+    ],
+    {..}
+  }
+]
+
+```
+
+See `orloclient -h` for more details.
+
+
+## Usage in Python
+
 ```python
 vagrant@debian-jessie:/vagrant$ ipython
 Python 2.7.9 (default, Mar  1 2015, 12:57:24)
@@ -72,6 +136,6 @@ In [9]: print(json.dumps(doc, indent=2))
 }
 ```
 
-# Tests
+## Tests
 
 There are two test suites, test_orloclient and test_integration. The former tests the orlo client functions while mocking the requests library, courtesy of [HTTPretty](https://github.com/gabrielfalcao/HTTPretty), while the integration tests run an actual Orlo server to test against.

--- a/orloclient/__main__.py
+++ b/orloclient/__main__.py
@@ -2,15 +2,33 @@ from __future__ import print_function
 import argparse
 import logging
 import json
+import sys
 import uuid
+from os.path import expanduser
 from orloclient import __version__
 from orloclient import OrloClient
+
+if sys.version_info >= (3, 0):
+    from configparser import ConfigParser
+else:
+    from ConfigParser import ConfigParser
+
 
 __author__ = 'alforbes'
 
 logging.basicConfig(format='%(message)s')
 logger = logging.getLogger('orloclient')
 logger.setLevel(logging.INFO)
+
+
+config = ConfigParser()
+config.add_section('client')
+config.set('client', 'uri', 'http://localhost:5000')
+config.read([
+    '/etc/orlo/orlo.ini',
+    expanduser('~/.orlo.ini'),
+    'orlo.ini',
+])
 
 
 def action_get_release(client, args):
@@ -107,9 +125,9 @@ def main():
     parser.add_argument('--version', '-v', action='version',
                         version='%(prog)s {}'.format(__version__))
     parser.add_argument('--uri', '-u', dest='uri',
-                        default='http://localhost:5000',
+                        default=config.get('client', 'uri'),
                         help="Address of orlo server")
-    parser.add_argument('--debug', help='Enable debug logging',
+    parser.add_argument('--debug', '-d', help='Enable debug logging',
                         action='store_true')
 
     subparsers = parser.add_subparsers(dest='object')

--- a/orloclient/__main__.py
+++ b/orloclient/__main__.py
@@ -82,6 +82,26 @@ def action_stop(client, args):
     ))
 
 
+def action_list_releases(client, args):
+    logger.debug('Filters: {}'.format(str(args.filter)))
+    kwargs = {}
+
+    for filter in args.filter:
+        l = filter.split('=')
+        if len(l) != 2:
+            logger.error("Invalid filter {}".format(str(filter)))
+            raise SystemExit(2)
+        kwargs[l[0]] = l[1]
+
+
+    releases = client.get_releases(raw=True, **kwargs)
+
+    if args.id_only:
+        print(json.dumps([r['id'] for r in releases], indent=2))
+    else:
+        print(json.dumps(releases, indent=2))
+
+
 def main():
     parser = argparse.ArgumentParser()
     parser.add_argument('--version', '-v', action='version',
@@ -121,11 +141,23 @@ def main():
         '-n', '--note', help='Note field value',
     )
 
+    pp_list = argparse.ArgumentParser(add_help=False)
+    pp_list.add_argument(
+        'filter', nargs='*',
+        help="Filters in the form parameter=value. See "
+             "http://orlo.readthedocs.io/en/latest/rest.html#get--releases "
+             "for valid parameters"
+    )
+    pp_list.add_argument(
+        '-i', '--id-only', action='store_true',
+       help="Only print id values, not full release json"
+    )
+
     pp_create_package = argparse.ArgumentParser(add_help=False)
     pp_create_package.add_argument('name', help='Package name')
     pp_create_package.add_argument('version', help='Package version')
 
-    se = subparsers.add_parser(
+    subparsers.add_parser(
         'create_release', help='Create a release',
         parents=[pp_create_release]
     ).set_defaults(func=action_create_release)
@@ -149,6 +181,10 @@ def main():
         'stop', help='Stop a package',
         parents=[pp_package]
     ).set_defaults(func=action_stop)
+    subparsers.add_parser(
+        'list_releases', help='List releases, filters optional',
+        parents=[pp_list]
+    ).set_defaults(func=action_list_releases)
 
     args = parser.parse_args()
     if args.debug:

--- a/orloclient/__main__.py
+++ b/orloclient/__main__.py
@@ -176,19 +176,19 @@ def main():
     pp_create_package.add_argument('version', help='Package version')
 
     subparsers.add_parser(
-        'create_release', help='Create a release',
+        'create-release', help='Create a release',
         parents=[pp_create_release]
     ).set_defaults(func=action_create_release)
     subparsers.add_parser(
-        'create_package', help='Create a package',
+        'create-package', help='Create a package',
         parents=[pp_release, pp_create_package]
     ).set_defaults(func=action_create_package)
     subparsers.add_parser(
-        'get_release', help='Fetch a release by ID',
+        'get-release', help='Fetch a release by ID',
         parents=[pp_release]
     ).set_defaults(func=action_get_release)
     subparsers.add_parser(
-        'get_package', help='Fetch a package by id',
+        'get-package', help='Fetch a package by id',
         parents=[pp_package]
     ).set_defaults(func=action_get_package)
     subparsers.add_parser(
@@ -200,7 +200,7 @@ def main():
         parents=[pp_package]
     ).set_defaults(func=action_stop)
     subparsers.add_parser(
-        'list_releases', help='List releases, filters optional',
+        'list', help='List releases, filters optional',
         parents=[pp_list]
     ).set_defaults(func=action_list_releases)
 

--- a/orloclient/client.py
+++ b/orloclient/client.py
@@ -413,20 +413,6 @@ class OrloClient(BaseClient):
         )
         return self._expect_200_json_response(response)
 
-    def deploy_release(self, release_id):
-        """
-        Send the command to deploy a release
-
-        :param release_id: Release ID to deploy
-        :return:
-        """
-        url = "{url}/releases/{rid}/deploy".format(url=self.uri, rid=release_id)
-
-        response = self._post(url, allow_redirects=False)
-        logger.debug(response)
-
-        return self._expect_200_json_response(response)
-
     def get_versions(self):
         """
         Return a JSON document of all package versions
@@ -439,3 +425,4 @@ class OrloClient(BaseClient):
         logger.debug(response)
 
         return self._expect_200_json_response(response)
+

--- a/orloclient/client.py
+++ b/orloclient/client.py
@@ -100,10 +100,6 @@ class OrloClient(BaseClient):
         """
         logger.debug("Entering get_releases")
 
-        if len(kwargs) is 0:
-            msg = "Must specify at least one filter for releases"
-            raise ClientError(msg)
-
         url = "{url}/releases".format(url=self.uri)
 
         filters = []

--- a/orloclient/client.py
+++ b/orloclient/client.py
@@ -91,11 +91,13 @@ class OrloClient(BaseClient):
 
         return releases_list[0]
 
-    def get_releases(self, **kwargs):
+    def get_releases(self, raw=False, **kwargs):
         """
         Fetch releases from the orlo API with filters
 
-        http://orlo.readthedocs.org/en/latest/rest.html#get--releases
+        See http://orlo.readthedocs.org/en/latest/rest.html#get--releases
+
+        :param bool raw: Return the raw dictionary rather than Release objects
         :param kwargs: Filters to apply
         """
         logger.debug("Entering get_releases")
@@ -116,9 +118,12 @@ class OrloClient(BaseClient):
         logger.debug(response)
 
         response_dict = self._expect_200_json_response(response)
-        releases_list = [Release(self, r['id']) for r in response_dict['releases']]
 
-        return releases_list
+        if raw:
+            return response_dict['releases']
+        else:
+            return [Release(self, r['id']) for r in response_dict['releases']]
+
 
     def get_release_json(self, release_id):
         """

--- a/setup.py
+++ b/setup.py
@@ -23,7 +23,7 @@ install_requires = [
 
 setup(
     name='orloclient',
-    version='0.4.3',
+    version='0.4.4',
     description='Client to the Orlo deployment _data capture API',
     author='Alex Forbes',
     author_email='alforbes@ebay.com',

--- a/tests/test_orloclient.py
+++ b/tests/test_orloclient.py
@@ -93,13 +93,6 @@ class TestGetReleases(OrloClientTest):
         release_list = self.orlo.get_releases(foo='bar')
         self.assertEqual(release_list[0].id, self.RELEASE_JSON['releases'][0]['id'])
 
-    def test_get_releases_unfiltered_raises(self):
-        """
-        Test that get/releases without a filter raises OrloClientError
-        """
-        with self.assertRaises(ClientError):
-            self.orlo.get_releases()
-
     @httpretty.activate
     def test_get_releases_filter(self):
         """

--- a/tests/test_orloclient.py
+++ b/tests/test_orloclient.py
@@ -592,25 +592,6 @@ class StatsTest(OrloClientTest):
         self.assertEqual(self.DOC, result)
 
 
-class DeployTest(OrloClientTest):
-    @httpretty.activate
-    def test_deploy(self):
-        """
-        Test /release/{rid}/deploy
-        """
-        rid = uuid.uuid4()
-        httpretty.register_uri(
-            httpretty.POST, '{}/releases/{}/deploy'.format(
-                self.URI,
-                rid),
-            status=204,
-            content_type='application/json',
-        )
-
-        result = self.orlo.deploy_release(rid)
-        self.assertEqual(True, result)
-
-
 class VersionsTest(OrloClientTest):
     @httpretty.activate
     def test_version(self):


### PR DESCRIPTION
* Add list sub-command for listing releases, supports filters as per http://orlo.readthedocs.io/en/latest/rest.html#get--releases
* Use hyphens in commands rather than underscores, like every sensible app does
* Read uri from config if present
* Remove some deprecated code